### PR TITLE
fix execute()" must be of the type int, "null" ret

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "hypernode/hypernodeshopware6helpers",
   "description": "Helpers for shopware6",
-  "version": "v1.0.1",
+  "version": "v1.0.2",
   "type": "shopware-platform-plugin",
   "license": "MIT",
   "authors": [

--- a/src/Command/SkipWizard.php
+++ b/src/Command/SkipWizard.php
@@ -35,5 +35,6 @@ class SkipWizard extends Command
         ];
         $databag = new QueryDataBag($databagVariables);
         $this->firstRunWizardController->frwFinish($databag, $context);
+        return 0;
     }
 }


### PR DESCRIPTION
Broke somewhere after a Shopware 6 update:

![shopware6](https://user-images.githubusercontent.com/1437341/117988323-99d13880-b33b-11eb-877b-af36b357c024.png)

```
shopware$ bin/console hypernode:skipwizard
13:54:35 CRITICAL  [console] Error thrown while running command "hypernode:skipwizard". Message: "Return value of "Hypernode\HypernodeShopware6Helpers\Command\SkipWizard::execute()" must be of the type int, "null" returned." ["exception" => TypeError { …},"command" => "hypernode:skipwizard","message" => "Return value of "Hypernode\HypernodeShopware6Helpers\Command\SkipWizard::execute()" must be of the type int, "null" returned."]

In Command.php line 259:

  Return value of "Hypernode\HypernodeShopware6Helpers\Command\SkipWizard::execute()" must be of the type int, "null" returned.

hypernode:skipwizard
```

For context see: https://github.com/symfony/symfony/issues/33747